### PR TITLE
Implement rollback support for transaction cache

### DIFF
--- a/src/brs/BlockchainProcessorImpl.java
+++ b/src/brs/BlockchainProcessorImpl.java
@@ -9,6 +9,7 @@ import brs.db.BlockDb;
 import brs.db.DerivedTable;
 import brs.db.TransactionDb;
 import brs.db.cache.DBCacheManagerImpl;
+import brs.db.cache.TransactionCache;
 import brs.db.store.BlockchainStore;
 import brs.db.store.DerivedTableManager;
 import brs.db.store.Stores;
@@ -1326,6 +1327,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
     List<Transaction> txs = block.getTransactions();
     blockchain.setLastBlock(block, previousBlock);
     txs.forEach(Transaction::unsetBlock);
+    TransactionCache.getInstance().removeBlockTransactions(block.getId());
     blockDb.deleteBlocksFrom(block.getId());
     blockListeners.notify(block, Event.BLOCK_POPPED);
     return previousBlock;

--- a/src/brs/db/cache/DBCacheManagerImpl.java
+++ b/src/brs/db/cache/DBCacheManagerImpl.java
@@ -61,5 +61,6 @@ public class DBCacheManagerImpl {
       if ( cache != null )
         cache.clear();
     }
+    TransactionCache.getInstance().clear();
   }
 }

--- a/src/brs/db/cache/TransactionCache.java
+++ b/src/brs/db/cache/TransactionCache.java
@@ -1,0 +1,98 @@
+package brs.db.cache;
+
+import brs.Transaction;
+import brs.props.Props;
+import brs.Signum;
+
+import java.util.*;
+
+/**
+ * Simple cache storing transactions for the most recent blocks.
+ */
+public final class TransactionCache {
+
+    private static TransactionCache instance;
+
+    public static synchronized TransactionCache getInstance() {
+        if (instance == null) {
+            int blocks = Signum.getPropertyService().getInt(Props.TRANSACTION_CACHE_BLOCK_COUNT);
+            instance = new TransactionCache(blocks);
+        }
+        return instance;
+    }
+
+    private final int blocksToCache;
+    private final Map<Long, Transaction> byId = new HashMap<>();
+    private final Map<String, Transaction> byHash = new HashMap<>();
+    private final Map<Long, List<Transaction>> byBlock = new HashMap<>();
+    private final Deque<Long> blockOrder = new ArrayDeque<>();
+
+    private TransactionCache(int blocksToCache) {
+        this.blocksToCache = blocksToCache;
+    }
+
+    /**
+     * Adds the transactions for a newly processed block.
+     */
+    public synchronized void addBlockTransactions(long blockId, List<Transaction> txs) {
+        if (blocksToCache <= 0 || txs == null) {
+            return;
+        }
+        blockOrder.addLast(blockId);
+        byBlock.put(blockId, txs);
+        for (Transaction t : txs) {
+            byId.put(t.getId(), t);
+            byHash.put(t.getFullHash(), t);
+        }
+        while (blockOrder.size() > blocksToCache) {
+            Long oldBlockId = blockOrder.removeFirst();
+            List<Transaction> oldTxs = byBlock.remove(oldBlockId);
+            if (oldTxs != null) {
+                for (Transaction t : oldTxs) {
+                    byId.remove(t.getId());
+                    byHash.remove(t.getFullHash());
+                }
+            }
+        }
+    }
+
+    public synchronized Transaction getById(long id) {
+        return byId.get(id);
+    }
+
+    public synchronized Transaction getByHash(String hash) {
+        return byHash.get(hash);
+    }
+
+    public synchronized List<Transaction> getBlockTransactions(long blockId) {
+        List<Transaction> txs = byBlock.get(blockId);
+        if (txs == null) {
+            return null;
+        }
+        return Collections.unmodifiableList(txs);
+    }
+
+    /**
+     * Removes all cached transactions for a popped off block.
+     */
+    public synchronized void removeBlockTransactions(long blockId) {
+        List<Transaction> txs = byBlock.remove(blockId);
+        if (txs != null) {
+            blockOrder.remove(blockId);
+            for (Transaction t : txs) {
+                byId.remove(t.getId());
+                byHash.remove(t.getFullHash());
+            }
+        }
+    }
+
+    /**
+     * Clears the entire transaction cache.
+     */
+    public synchronized void clear() {
+        byId.clear();
+        byHash.clear();
+        byBlock.clear();
+        blockOrder.clear();
+    }
+}

--- a/src/brs/db/sql/SqlBlockDb.java
+++ b/src/brs/db/sql/SqlBlockDb.java
@@ -4,6 +4,7 @@ import brs.Block;
 import brs.Signum;
 import brs.SignumException;
 import brs.db.BlockDb;
+import brs.db.cache.TransactionCache;
 import brs.schema.tables.records.BlockRecord;
 import org.jooq.*;
 import org.jooq.Record;
@@ -138,6 +139,7 @@ public class SqlBlockDb implements BlockDb {
       .execute();
 
     Signum.getDbs().getTransactionDb().saveTransactions(block.getTransactions());
+    TransactionCache.getInstance().addBlockTransactions(block.getId(), block.getTransactions());
 
     if (block.getPreviousBlockId() != 0) {
       ctx.update(BLOCK)

--- a/src/brs/props/Props.java
+++ b/src/brs/props/Props.java
@@ -140,6 +140,9 @@ public class Props {
     public static final Prop<Integer> BRS_AT_PROCESSOR_CACHE_BLOCK_COUNT = new Prop<>("node.atProcessorCacheBlockCount",
             1000);
 
+    // Number of blocks to keep in the transaction cache
+    public static final Prop<Integer> TRANSACTION_CACHE_BLOCK_COUNT = new Prop<>("node.transactionCacheBlockCount", 1000);
+
     public static final Prop<Integer> DB_INSERT_BATCH_MAX_SIZE = new Prop<>("DB.InsertBatchMaxSize", 10000);
 
     // P2P options


### PR DESCRIPTION
## Summary
- handle rollback by clearing transactions from cache
- wipe transaction cache on `dbCacheManager.flushCache`
- remove popped transactions from cache when popping blocks

## Testing
- `./gradlew test` *(fails: 3 tests)*


------
https://chatgpt.com/codex/tasks/task_e_68447c858d70832abf2343eebe4559de