### PR TITLE
Fix junit tx cache config

### DIFF
--- a/conf/junit/node-default.properties
+++ b/conf/junit/node-default.properties
@@ -8,3 +8,6 @@ node.network = signum.net.MockNetwork
 #DB.Url=jdbc:h2:mem:signum-mock;DB_CLOSE_ON_EXIT=FALSE
 # Database connection JDBC url
 DB.Url=jdbc:sqlite:file:./db/signum-mock.sqlite.db
+
+# Disable transaction caching for unit tests
+node.transactionCacheBlockCount=0


### PR DESCRIPTION
## Summary
- disable transaction cache for junit tests

## Testing
- `./gradlew test --tests chain.AliasTest --rerun-tasks`

------
https://chatgpt.com/codex/tasks/task_e_6844cbcd77ac832a9e488234a94157ab