### PR TITLE
Add block height stats to tx cache log

### DIFF
--- a/src/brs/db/sql/SqlBlockDb.java
+++ b/src/brs/db/sql/SqlBlockDb.java
@@ -139,7 +139,7 @@ public class SqlBlockDb implements BlockDb {
       .execute();
 
     Signum.getDbs().getTransactionDb().saveTransactions(block.getTransactions());
-    TransactionCache.getInstance().addBlockTransactions(block.getId(), block.getTransactions());
+    TransactionCache.getInstance().addBlockTransactions(block.getId(), block.getHeight(), block.getTransactions());
 
     if (block.getPreviousBlockId() != 0) {
       ctx.update(BLOCK)

--- a/src/brs/statistics/StatisticsManagerImpl.java
+++ b/src/brs/statistics/StatisticsManagerImpl.java
@@ -1,6 +1,7 @@
 package brs.statistics;
 
 import brs.services.TimeService;
+import brs.db.cache.TransactionCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +47,18 @@ public class StatisticsManagerImpl {
       float blocksPerSecond = 500 / (float) (timeService.getEpochTime() - firstBlockAdded);
 
       if (logger.isInfoEnabled()) {
-        final String handleText = "handling {} blocks/s" + cacheStatistics.values().stream().map(cacheInfo -> " " + cacheInfo.getCacheInfoAndReset()).collect(Collectors.joining());
+        final TransactionCache txCache = TransactionCache.getInstance();
+        final String txCacheInfo = String.format(
+            " transaction cache holds %d transaction%s from height %d to %d/cache hits %d requests handled",
+            txCache.getTransactionCount(),
+            txCache.getTransactionCount() == 1 ? "" : "s",
+            txCache.getMinTxHeight(),
+            txCache.getMaxTxHeight(),
+            txCache.getAndResetCacheHits());
+
+        final String handleText = "handling {} blocks/s" +
+            cacheStatistics.values().stream().map(cacheInfo -> " " + cacheInfo.getCacheInfoAndReset()).collect(Collectors.joining()) +
+            txCacheInfo;
         logger.info(handleText, String.format("%.2f", blocksPerSecond));
       }
 


### PR DESCRIPTION
## Summary
- track cached block heights and maintain min/max transaction heights
- include transaction cache height range in periodic log output

## Testing
- `./gradlew test` *(fails: AliasTest & SendTransactionsTest)*

------
https://chatgpt.com/codex/tasks/task_e_684536413098832aae35bff9acba2a4d