### PR TITLE
Add conditional force index hints

### DIFF
--- a/src/brs/db/sql/SqlATStore.java
+++ b/src/brs/db/sql/SqlATStore.java
@@ -13,6 +13,7 @@ import brs.schema.tables.records.AtStateRecord;
 
 import brs.util.CollectionWithIndex;
 import org.jooq.*;
+import org.jooq.SQLDialect;
 import org.jooq.Record;
 import org.jooq.exception.DataAccessException;
 import org.slf4j.Logger;
@@ -214,8 +215,13 @@ public class SqlATStore implements ATStore {
   @Override
   public Collection<brs.at.AT> getATs(Collection<Long> ids) {
     return Db.useDSLContext(ctx -> {
+      Table<AtStateRecord> atStateTable = AT_STATE;
+      if (ctx.dialect() == SQLDialect.MARIADB || ctx.dialect() == SQLDialect.MYSQL) {
+        atStateTable = AT_STATE.forceIndex("at_state_id_latest_idx");
+      }
+
       Result<Record> result = ctx.select(AT.fields()).select(AT_STATE.fields())
-        .from(AT.join( AT_STATE.forceIndex("at_state_id_latest_idx")).on(AT.ID.eq(AT_STATE.AT_ID)))
+        .from(AT.join(atStateTable).on(AT.ID.eq(AT_STATE.AT_ID)))
         .where(AT.LATEST.isTrue()).and(AT_STATE.LATEST.isTrue()).and(AT.ID.in(ids))
         .fetch();
 

--- a/src/brs/db/sql/SqlBlockchainStore.java
+++ b/src/brs/db/sql/SqlBlockchainStore.java
@@ -14,6 +14,7 @@ import brs.schema.tables.records.TransactionRecord;
 import brs.util.Convert;
 
 import org.jooq.*;
+import org.jooq.SQLDialect;
 import org.jooq.impl.DSL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -400,7 +401,12 @@ public class SqlBlockchainStore implements BlockchainStore {
     int commitmentHeight = Math.min(height - commitmentWait, endHeight);
 
     Collection<byte[]> commitmmentAddBytes = Db.useDSLContext(ctx -> {
-      SelectConditionStep<Record1<byte[]>> select = ctx.select(TRANSACTION.ATTACHMENT_BYTES).from(TRANSACTION).where(TRANSACTION.TYPE.eq(TransactionType.TYPE_SIGNA_MINING.getType()))
+      Table<TransactionRecord> txTable = TRANSACTION;
+      if (ctx.dialect() == SQLDialect.MARIADB || ctx.dialect() == SQLDialect.MYSQL) {
+        txTable = TRANSACTION.forceIndex("tx_sender_type_subtype_height_idx");
+      }
+
+      SelectConditionStep<Record1<byte[]>> select = ctx.select(TRANSACTION.ATTACHMENT_BYTES).from(txTable).where(TRANSACTION.TYPE.eq(TransactionType.TYPE_SIGNA_MINING.getType()))
         .and(TRANSACTION.SUBTYPE.eq(TransactionType.SUBTYPE_SIGNA_MINING_COMMITMENT_ADD))
         .and(TRANSACTION.HEIGHT.le(commitmentHeight));
       if (accountId != 0L)
@@ -408,7 +414,12 @@ public class SqlBlockchainStore implements BlockchainStore {
       return select.fetch().getValues(TRANSACTION.ATTACHMENT_BYTES);
     });
     Collection<byte[]> commitmmentRemoveBytes = Db.useDSLContext(ctx -> {
-      SelectConditionStep<Record1<byte[]>> select = ctx.select(TRANSACTION.ATTACHMENT_BYTES).from(TRANSACTION).where(TRANSACTION.TYPE.eq(TransactionType.TYPE_SIGNA_MINING.getType()))
+      Table<TransactionRecord> txTable = TRANSACTION;
+      if (ctx.dialect() == SQLDialect.MARIADB || ctx.dialect() == SQLDialect.MYSQL) {
+        txTable = TRANSACTION.forceIndex("tx_sender_type_subtype_height_idx");
+      }
+
+      SelectConditionStep<Record1<byte[]>> select = ctx.select(TRANSACTION.ATTACHMENT_BYTES).from(txTable).where(TRANSACTION.TYPE.eq(TransactionType.TYPE_SIGNA_MINING.getType()))
         .and(TRANSACTION.SUBTYPE.eq(TransactionType.SUBTYPE_SIGNA_MINING_COMMITMENT_REMOVE))
         .and(TRANSACTION.HEIGHT.le(endHeight));
       if (accountId != 0L)


### PR DESCRIPTION
## Summary
- only apply `forceIndex` on MariaDB or MySQL dialects
- ensure queries still work on SQLite and PostgreSQL

## Testing
- `./gradlew test` *(fails: output truncated, manual run aborted)*


------
https://chatgpt.com/codex/tasks/task_e_68472f4f0d34832a8cb8f0087e717884