### PR TITLE
chore: upgrade flyway and jooq plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,8 @@ plugins {
   id 'org.gradle.crypto.checksum' version '1.4.0'
   id 'com.palantir.git-version' version '4.0.0'
   id 'io.spring.dependency-management' version '1.1.7'
-  id 'nu.studer.jooq' version '7.2'
-  id "org.flywaydb.flyway" version "8.5.13"
+  id 'nu.studer.jooq' version '10.1.1'
+  id "org.flywaydb.flyway" version "11.11.1"
   id "de.undercouch.download" version "5.6.0"
   id 'jacoco'
   id "com.github.node-gradle.node" version "7.1.0"
@@ -41,8 +41,9 @@ dependencies {
     implementation 'org.jocl:jocl:2.0.5'
 
     implementation 'org.jooq:jooq:3.20.6'
-    implementation 'org.flywaydb:flyway-core:8.5.13'
-    implementation 'org.flywaydb:flyway-mysql:8.5.13'
+    implementation 'org.flywaydb:flyway-core:11.11.1'
+    implementation 'org.flywaydb:flyway-mysql:11.11.1'
+    implementation 'org.flywaydb:flyway-database-postgresql:11.11.1'
     implementation 'org.postgresql:postgresql:42.7.7'
     implementation 'com.kohlschutter.junixsocket:junixsocket-core:2.10.1'
     implementation 'org.mariadb.jdbc:mariadb-java-client:3.5.5'


### PR DESCRIPTION
## Summary
- upgrade Flyway plugin and dependencies to 11.11.1 with PostgreSQL support
- bump nu.studer.jooq Gradle plugin to 10.1.1

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68a823cebc04832a9a2a50d8b9960376