### PR TITLE
chore: upgrade flyway and jooq plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,8 @@ plugins {
   id 'org.gradle.crypto.checksum' version '1.4.0'
   id 'com.palantir.git-version' version '4.0.0'
   id 'io.spring.dependency-management' version '1.1.7'
-  id 'nu.studer.jooq' version '7.2'
-  id "org.flywaydb.flyway" version "8.5.13"
+  id 'nu.studer.jooq' version '10.1.1'
+  id "org.flywaydb.flyway" version "11.11.1"
   id "de.undercouch.download" version "5.6.0"
   id 'jacoco'
   id "com.github.node-gradle.node" version "7.1.0"
@@ -41,8 +41,9 @@ dependencies {
     implementation 'org.jocl:jocl:2.0.5'
 
     implementation 'org.jooq:jooq:3.20.6'
-    implementation 'org.flywaydb:flyway-core:8.5.13'
-    implementation 'org.flywaydb:flyway-mysql:8.5.13'
+    implementation 'org.flywaydb:flyway-core:11.11.1'
+    implementation 'org.flywaydb:flyway-mysql:11.11.1'
+    implementation 'org.flywaydb:flyway-database-postgresql:11.11.1'
     implementation 'org.postgresql:postgresql:42.7.7'
     implementation 'com.kohlschutter.junixsocket:junixsocket-core:2.10.1'
     implementation 'org.mariadb.jdbc:mariadb-java-client:3.5.5'

--- a/resources/db/migration_postgres/V1__initial_model.sql
+++ b/resources/db/migration_postgres/V1__initial_model.sql
@@ -431,25 +431,6 @@ create index if not exists idx_16512_escrow_decision_escrow_id_height_idx
 create index if not exists idx_16512_escrow_decision_account_id_height_idx
   on escrow_decision (account_id, height desc);
 
-create table if not exists flyway_schema_history
-(
-  installed_rank bigint                                             not null
-    constraint idx_16517_primary
-      primary key,
-  version        varchar(50)              default NULL::character varying,
-  description    varchar(200)                                       not null,
-  type           varchar(20)                                        not null,
-  script         varchar(1000)                                      not null,
-  checksum       bigint,
-  installed_by   varchar(100)                                       not null,
-  installed_on   timestamp with time zone default CURRENT_TIMESTAMP not null,
-  execution_time bigint                                             not null,
-  success        boolean                                            not null
-);
-
-create index if not exists idx_16517_flyway_schema_history_s_idx
-  on flyway_schema_history (success);
-
 create table if not exists goods
 (
   db_id       bigserial


### PR DESCRIPTION
## Summary
- upgrade Flyway plugin and dependencies to 11.11.1 with PostgreSQL support
- bump nu.studer.jooq Gradle plugin to 10.1.1
- remove manual Flyway schema history table from PostgreSQL migration so migrations run correctly

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68a823cebc04832a9a2a50d8b9960376