### PR TITLE
Ensure ask/bid order tables registered for trimming

### DIFF
--- a/src/brs/db/store/DerivedTableManager.java
+++ b/src/brs/db/store/DerivedTableManager.java
@@ -18,7 +18,11 @@ public class DerivedTableManager {
   }
 
   public void registerDerivedTable(DerivedTable table) {
-    logger.info("Registering derived table " + table.getClass());
+    if (derivedTables.contains(table)) {
+      logger.debug("Derived table {} already registered", table.getTable());
+      return;
+    }
+    logger.info("Registering derived table {}", table.getTable());
     derivedTables.add(table);
   }
 

--- a/test/java/brs/db/sql/SqlOrderStoreTrimRegistrationTest.java
+++ b/test/java/brs/db/sql/SqlOrderStoreTrimRegistrationTest.java
@@ -1,0 +1,26 @@
+package brs.db.sql;
+
+import brs.db.store.DerivedTableManager;
+import brs.db.store.OrderStore;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SqlOrderStoreTrimRegistrationTest {
+
+  @Test
+  public void askAndBidTablesAreRegisteredForTrim() {
+    DerivedTableManager derivedTableManager = new DerivedTableManager();
+    OrderStore orderStore = new SqlOrderStore(derivedTableManager);
+
+    Set<String> registeredTables = derivedTableManager.getDerivedTables().stream()
+      .map(table -> table.getTable())
+      .collect(Collectors.toSet());
+
+    assertTrue(registeredTables.contains("ask_order"), "ask_order should be registered for trimming");
+    assertTrue(registeredTables.contains("bid_order"), "bid_order should be registered for trimming");
+  }
+}


### PR DESCRIPTION
## Summary
- prevent duplicate derived-table registrations and log table names for easier diagnostics
- rely on the order store's built-in registration instead of double-registering ask/bid order tables
- add a unit test confirming the order tables are included in the derived-table registry

## Testing
- `./gradlew test --tests brs.db.sql.SqlOrderStoreTrimRegistrationTest --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68c9b019a7a0832aa9521e12e9261d5a