### PR TITLE
Harden monetary arithmetic

### DIFF
--- a/src/brs/Block.java
+++ b/src/brs/Block.java
@@ -148,6 +148,10 @@ public class Block {
                             + payloadLength + " height " + height + "previd "
                             + previousBlockId);
         }
+        if (totalAmountNqt < 0 || totalFeeNqt < 0 || totalFeeCashBackNqt < 0 || totalFeeBurntNqt < 0) {
+            throw new SignumException.NotValidException(
+                    "attempted to create a block with negative monetary totals at height " + height);
+        }
         this.version = version;
         this.timestamp = timestamp;
         this.previousBlockId = previousBlockId;

--- a/src/brs/BlockchainProcessorImpl.java
+++ b/src/brs/BlockchainProcessorImpl.java
@@ -2301,8 +2301,8 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
                         throw new TransactionNotAcceptedException(e.getMessage(), transaction);
                     }
 
-                    calculatedTotalAmount += transaction.getAmountNqt();
-                    calculatedTotalFee += transaction.getFeeNqt();
+                    calculatedTotalAmount = Convert.safeAdd(calculatedTotalAmount, transaction.getAmountNqt());
+                    calculatedTotalFee = Convert.safeAdd(calculatedTotalFee, transaction.getFeeNqt());
                     digest.update(transaction.getBytes());
                     indirectIncomingService.processTransaction(transaction);
                     feeArray[slotIdx] = transaction.getFeeNqt();
@@ -2484,12 +2484,13 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
 
         long calculatedRemainingAmount = 0;
         long calculatedRemainingFee = 0;
-        calculatedRemainingAmount += atBlock.getTotalAmount();
-        calculatedRemainingFee += atBlock.getTotalFees();
+        calculatedRemainingAmount = Convert.safeAdd(calculatedRemainingAmount, atBlock.getTotalAmount());
+        calculatedRemainingFee = Convert.safeAdd(calculatedRemainingFee, atBlock.getTotalFees());
 
         start = System.nanoTime();
         if (subscriptionService.isEnabled()) {
-            calculatedRemainingFee += subscriptionService.applyUnconfirmed(block.getTimestamp(), block.getHeight());
+            calculatedRemainingFee = Convert.safeAdd(calculatedRemainingFee,
+                    subscriptionService.applyUnconfirmed(block.getTimestamp(), block.getHeight()));
         }
         subscriptionTimeNanos = (System.nanoTime() - start);
 
@@ -2987,8 +2988,8 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
                             try {
                                 transactionService.validate(transaction);
                                 payloadSize -= transaction.getSize();
-                                totalAmountNqt += transaction.getAmountNqt();
-                                totalFeeNqt += transaction.getFeeNqt();
+                                totalAmountNqt = Convert.safeAdd(totalAmountNqt, transaction.getAmountNqt());
+                                totalFeeNqt = Convert.safeAdd(totalFeeNqt, transaction.getFeeNqt());
                                 if (Signum.getFluxCapacitor().getValue(FluxValues.SMART_FEES, blockHeight)) {
                                     totalFeeCashBackNqt = Convert.safeAdd(totalFeeCashBackNqt, transaction.getFeeNqt()
                                             / propertyService.getInt(Props.CASH_BACK_FACTOR));

--- a/src/brs/IndirectIncoming.java
+++ b/src/brs/IndirectIncoming.java
@@ -1,5 +1,7 @@
 package brs;
 
+import brs.util.Convert;
+
 public class IndirectIncoming {
   private final long accountId;
   private final long transactionId;
@@ -28,7 +30,7 @@ public class IndirectIncoming {
   }
   
   public void addAmount(long add) {
-    amount += add;
+    amount = Convert.safeAdd(amount, add);
   }
   
   public long getQuantity() {
@@ -36,7 +38,7 @@ public class IndirectIncoming {
   }
   
   public void addQuantity(long add) {
-    quantity += add;
+    quantity = Convert.safeAdd(quantity, add);
   }
 
   public int getHeight() {

--- a/src/brs/Transaction.java
+++ b/src/brs/Transaction.java
@@ -252,6 +252,7 @@ public class Transaction implements Comparable<Transaction> {
 
         if ((type == null || type.isSigned()) && (deadline < 1
                 || feeNqt > Constants.MAX_BALANCE_NQT
+                || feeNqt < 0
                 || amountNqt < 0
                 || amountNqt > Constants.MAX_BALANCE_NQT
                 || type == null)) {

--- a/src/brs/TransactionType.java
+++ b/src/brs/TransactionType.java
@@ -1393,7 +1393,7 @@ public abstract class TransactionType {
 
         boolean unconfirmed = !Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX);
         long circulatingSupply = assetExchange.getAssetCirculatingSupply(asset, false, unconfirmed);
-        long newSupply = circulatingSupply + attachment.getQuantityQnt();
+        long newSupply = Convert.safeAdd(circulatingSupply, attachment.getQuantityQnt());
         if (newSupply > Constants.MAX_ASSET_QUANTITY_QNT) {
           return false;
         }
@@ -1437,7 +1437,7 @@ public abstract class TransactionType {
 
         boolean unconfirmed = !Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX);
         long circulatingSupply = assetExchange.getAssetCirculatingSupply(asset, false, unconfirmed);
-        long newSupply = circulatingSupply + attachment.getQuantityQnt();
+        long newSupply = Convert.safeAdd(circulatingSupply, attachment.getQuantityQnt());
         if (newSupply > Constants.MAX_ASSET_QUANTITY_QNT) {
           throw new SignumException.NotCurrentlyValidException("Maximum circulating supply QNT is " + Constants.MAX_ASSET_QUANTITY_QNT);
         }
@@ -1595,7 +1595,7 @@ public abstract class TransactionType {
           if(Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, transaction.getHeight()) && holder.getAccountId() == senderAccount.getId()){
             continue;
           }
-          circulatingQuantityQNT += holder.getUnconfirmedQuantityQnt();
+          circulatingQuantityQNT = Convert.safeAdd(circulatingQuantityQNT, holder.getUnconfirmedQuantityQnt());
         }
         if(circulatingQuantityQNT <= 0L) {
           accountService.addToUnconfirmedAssetBalanceQNT(senderAccount, assetToDistribute, attachment.getQuantityQnt());
@@ -1695,7 +1695,7 @@ public abstract class TransactionType {
           }
           long holderQuantity = Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, transaction.getHeight()) ?
             holder.getQuantityQnt() : holder.getUnconfirmedQuantityQnt();
-          circulatingQuantityQNT += holderQuantity;
+          circulatingQuantityQNT = Convert.safeAdd(circulatingQuantityQNT, holderQuantity);
         }
         BigInteger circulatingQuantity = BigInteger.valueOf(circulatingQuantityQNT);
 
@@ -1722,14 +1722,14 @@ public abstract class TransactionType {
             quantity = quantityToDistribute.multiply(BigInteger.valueOf(holderQuantity))
                 .divide(circulatingQuantity).longValue();
 
-            quantityDistributed += quantity;
+            quantityDistributed = Convert.safeAdd(quantityDistributed, quantity);
           }
 
           long amount = 0L;
           if(transaction.getAmountNqt() > 0L) {
             amount = amountToDistribute.multiply(BigInteger.valueOf(holderQuantity))
                 .divide(circulatingQuantity).longValue();
-            amountDistributed += amount;
+            amountDistributed = Convert.safeAdd(amountDistributed, amount);
           }
 
           IndirectIncoming indirect = new IndirectIncoming(holder.getAccountId(), transaction.getId(),

--- a/src/brs/at/AtApiPlatformImpl.java
+++ b/src/brs/at/AtApiPlatformImpl.java
@@ -13,6 +13,7 @@ import brs.Account.AccountAsset;
 import brs.crypto.Crypto;
 import brs.fluxcapacitor.FluxValues;
 import brs.props.Props;
+import brs.util.Convert;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -633,7 +634,7 @@ public class AtApiPlatformImpl extends AtApiImpl {
 
     boolean unconfirmed = !Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, state.getHeight());
     long circulatingSupply = Signum.getAssetExchange().getAssetCirculatingSupply(asset, false, unconfirmed);
-    long newSupply = circulatingSupply + quantity;
+    long newSupply = Convert.safeAdd(circulatingSupply, quantity);
     if (newSupply > Constants.MAX_ASSET_QUANTITY_QNT) {
       // do not mint extra to keep the limit
       logger.debug(

--- a/src/brs/at/AtController.java
+++ b/src/brs/at/AtController.java
@@ -236,12 +236,13 @@ public abstract class AtController {
             long atAccountBalance = getATAccountBalance(id);
             long atStateBalance = at.getgBalance();
 
-            if (at.freezeOnSameBalance() && (atAccountBalance - atStateBalance < at.minActivationAmount())) {
+            if (at.freezeOnSameBalance()
+                    && (Convert.safeSubtract(atAccountBalance, atStateBalance) < at.minActivationAmount())) {
                 continue;
             }
 
-            if (atAccountBalance >= AtConstants.getInstance().stepFee(at.getVersion())
-                    * AtConstants.getInstance().apiStepMultiplier(at.getVersion())) {
+            if (atAccountBalance >= Convert.safeMultiply(AtConstants.getInstance().stepFee(at.getVersion()),
+                    AtConstants.getInstance().apiStepMultiplier(at.getVersion()))) {
                 try {
                     at.setgBalance(atAccountBalance);
                     at.setHeight(blockHeight);
@@ -251,9 +252,10 @@ public abstract class AtController {
                     runSteps(at);
                     indirectsCount = at.getIndirectsCount();
 
-                    long fee = at.getMachineState().steps * AtConstants.getInstance().stepFee(at.getVersion());
+                    long fee = Convert.safeMultiply(at.getMachineState().steps,
+                            AtConstants.getInstance().stepFee(at.getVersion()));
                     if (at.getMachineState().dead) {
-                        fee += at.getgBalance();
+                        fee = Convert.safeAdd(fee, at.getgBalance());
                         at.setgBalance(0L);
                     }
                     at.setpBalance(at.getgBalance());
@@ -262,10 +264,10 @@ public abstract class AtController {
                     if (!Signum.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_4, blockHeight)) {
                         totalAmount = amount;
                     } else {
-                        totalAmount += amount;
+                        totalAmount = Convert.safeAdd(totalAmount, amount);
                     }
 
-                    totalFee += fee;
+                    totalFee = Convert.safeAdd(totalFee, fee);
                     AT.addPendingFee(id, fee, blockHeight, generatorId);
 
                     payload += costOfOneAT;
@@ -314,12 +316,13 @@ public abstract class AtController {
                 at.setWaitForNumberOfBlocks(at.getSleepBetween());
 
                 long atAccountBalance = getATAccountBalance(atIdLong);
-                if (atAccountBalance < AtConstants.getInstance().stepFee(at.getVersion())
-                        * AtConstants.getInstance().apiStepMultiplier(at.getVersion())) {
+                if (atAccountBalance < Convert.safeMultiply(AtConstants.getInstance().stepFee(at.getVersion()),
+                        AtConstants.getInstance().apiStepMultiplier(at.getVersion()))) {
                     throw new AtException("AT has insufficient balance to run");
                 }
 
-                if (at.freezeOnSameBalance() && (atAccountBalance - at.getgBalance() < at.minActivationAmount())) {
+                if (at.freezeOnSameBalance()
+                        && (Convert.safeSubtract(atAccountBalance, at.getgBalance()) < at.minActivationAmount())) {
                     throw new AtException("AT should be frozen due to unchanged balance");
                 }
 
@@ -333,9 +336,10 @@ public abstract class AtController {
 
                 runSteps(at);
 
-                long fee = at.getMachineState().steps * AtConstants.getInstance().stepFee(at.getVersion());
+                long fee = Convert.safeMultiply(at.getMachineState().steps,
+                        AtConstants.getInstance().stepFee(at.getVersion()));
                 if (at.getMachineState().dead) {
-                    fee += at.getgBalance();
+                    fee = Convert.safeAdd(fee, at.getgBalance());
                     at.setgBalance(0L);
                 }
                 at.setpBalance(at.getgBalance());
@@ -343,10 +347,10 @@ public abstract class AtController {
                 if (!Signum.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_4, blockHeight)) {
                     totalAmount = makeTransactions(at, blockHeight, generatorId);
                 } else {
-                    totalAmount += makeTransactions(at, blockHeight, generatorId);
+                    totalAmount = Convert.safeAdd(totalAmount, makeTransactions(at, blockHeight, generatorId));
                 }
 
-                totalFee += fee;
+                totalFee = Convert.safeAdd(totalFee, fee);
                 AT.addPendingFee(atIdLong, fee, blockHeight, generatorId);
 
                 processedATs.add(at);
@@ -398,12 +402,13 @@ public abstract class AtController {
                 at.setWaitForNumberOfBlocks(at.getSleepBetween());
 
                 long atAccountBalance = getATAccountBalance(atIdLong);
-                if (atAccountBalance < AtConstants.getInstance().stepFee(at.getVersion())
-                        * AtConstants.getInstance().apiStepMultiplier(at.getVersion())) {
+                if (atAccountBalance < Convert.safeMultiply(AtConstants.getInstance().stepFee(at.getVersion()),
+                        AtConstants.getInstance().apiStepMultiplier(at.getVersion()))) {
                     throw new AtException("AT has insufficient balance to run");
                 }
 
-                if (at.freezeOnSameBalance() && (atAccountBalance - at.getgBalance() < at.minActivationAmount())) {
+                if (at.freezeOnSameBalance()
+                        && (Convert.safeSubtract(atAccountBalance, at.getgBalance()) < at.minActivationAmount())) {
                     throw new AtException("AT should be frozen due to unchanged balance");
                 }
 
@@ -417,9 +422,10 @@ public abstract class AtController {
 
                 runSteps(at);
 
-                long fee = at.getMachineState().steps * AtConstants.getInstance().stepFee(at.getVersion());
+                long fee = Convert.safeMultiply(at.getMachineState().steps,
+                        AtConstants.getInstance().stepFee(at.getVersion()));
                 if (at.getMachineState().dead) {
-                    fee += at.getgBalance();
+                    fee = Convert.safeAdd(fee, at.getgBalance());
                     at.setgBalance(0L);
                 }
                 at.setpBalance(at.getgBalance());
@@ -427,10 +433,10 @@ public abstract class AtController {
                 if (!Signum.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_4, blockHeight)) {
                     totalAmount = makeTransactions(at, blockHeight, generatorId);
                 } else {
-                    totalAmount += makeTransactions(at, blockHeight, generatorId);
+                    totalAmount = Convert.safeAdd(totalAmount, makeTransactions(at, blockHeight, generatorId));
                 }
 
-                totalFee += fee;
+                totalFee = Convert.safeAdd(totalFee, fee);
                 AT.addPendingFee(atIdLong, fee, blockHeight, generatorId);
 
                 processedATs.add(at);
@@ -548,7 +554,7 @@ public abstract class AtController {
         }
 
         for (AtTransaction tx : ordered) {
-            totalAmount += tx.getAmount();
+            totalAmount = Convert.safeAdd(totalAmount, tx.getAmount());
             AT.addPendingTransaction(tx, blockHeight, generatorId);
             if (logger.isDebugEnabled()) {
                 logger.debug(

--- a/src/brs/services/impl/BlockServiceImpl.java
+++ b/src/brs/services/impl/BlockServiceImpl.java
@@ -253,8 +253,8 @@ public class BlockServiceImpl implements BlockService {
                 Account distAccount = accountService.getOrAddAccount(distAccountId);
                 if (distAccount != null) {
                     @SuppressWarnings("checkstyle:LineLengthCheck")
-                    long distAmount = (blockRewardTotal * blockDistribution.get(distAccountId)) / 1000L;
-                    blockReward -= distAmount;
+                    long distAmount = Convert.safeMultiply(blockRewardTotal, blockDistribution.get(distAccountId)) / 1000L;
+                    blockReward = Convert.safeSubtract(blockReward, distAmount);
                     accountService.addToBalanceAndUnconfirmedBalanceNQT(distAccount, distAmount);
                     accountService.addToForgedBalanceNQT(distAccount, distAmount);
                 }
@@ -263,10 +263,10 @@ public class BlockServiceImpl implements BlockService {
         if (!Signum.getFluxCapacitor().getValue(FluxValues.REWARD_RECIPIENT_ENABLE)) {
             accountService.addToBalanceAndUnconfirmedBalanceNQT(
                     generatorAccount,
-                    block.getTotalFeeNqt() + blockReward);
+                    Convert.safeAdd(block.getTotalFeeNqt(), blockReward));
             accountService.addToForgedBalanceNQT(
                     generatorAccount,
-                    block.getTotalFeeNqt() + blockReward);
+                    Convert.safeAdd(block.getTotalFeeNqt(), blockReward));
         } else {
             Account rewardAccount = getRewardAccount(block);
 
@@ -291,10 +291,10 @@ public class BlockServiceImpl implements BlockService {
             }
             accountService.addToBalanceAndUnconfirmedBalanceNQT(
                     rewardAccount,
-                    rewardFeesNqt + blockReward);
+                    Convert.safeAdd(rewardFeesNqt, blockReward));
             accountService.addToForgedBalanceNQT(
                     rewardAccount,
-                    rewardFeesNqt + blockReward);
+                    Convert.safeAdd(rewardFeesNqt, blockReward));
         }
 
         for (Transaction transaction : block.getTransactions()) {

--- a/src/brs/services/impl/SubscriptionServiceImpl.java
+++ b/src/brs/services/impl/SubscriptionServiceImpl.java
@@ -168,7 +168,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
             }
             if (applyUnconfirmed(subscription, height)) {
                 appliedSubscriptions.add(subscription);
-                totalFees += getFee(height);
+                totalFees = Convert.safeAdd(totalFees, getFee(height));
             } else {
                 removeSubscriptions.add(subscription.getId());
             }

--- a/src/brs/web/api/http/handler/DistributeToAssetHolders.java
+++ b/src/brs/web/api/http/handler/DistributeToAssetHolders.java
@@ -103,7 +103,11 @@ public final class DistributeToAssetHolders extends CreateTransaction {
     CollectionWithIndex<AccountAsset> holders = assetExchange.getAssetAccounts(asset, false, minimumQuantity, unconfirmed, -1, -1);
     long circulatingSupply = 0;
     for(AccountAsset holder : holders) {
-      circulatingSupply += holder.getQuantityQnt();
+      try {
+        circulatingSupply = Convert.safeAdd(circulatingSupply, holder.getQuantityQnt());
+      } catch (ArithmeticException e) {
+        return JSONResponses.incorrect(QUANTITY_MININUM_QNT_PARAMETER);
+      }
     }
     if(circulatingSupply == 0L) {
       return JSONResponses.incorrect(QUANTITY_MININUM_QNT_PARAMETER);

--- a/src/brs/web/api/http/handler/MintAsset.java
+++ b/src/brs/web/api/http/handler/MintAsset.java
@@ -4,6 +4,7 @@ import brs.*;
 import brs.assetexchange.AssetExchange;
 import brs.fluxcapacitor.FluxValues;
 import brs.services.ParameterService;
+import brs.util.Convert;
 import brs.web.api.http.common.APITransactionManager;
 import brs.web.api.http.common.JSONResponses;
 import brs.web.api.http.common.LegacyDocTag;
@@ -50,7 +51,12 @@ public final class MintAsset extends CreateTransaction {
 
     boolean unconfirmed = !Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX);
     long circulatingSupply = assetExchange.getAssetCirculatingSupply(asset, false, unconfirmed);
-    long newSupply = circulatingSupply + quantityQNT;
+    long newSupply;
+    try {
+      newSupply = Convert.safeAdd(circulatingSupply, quantityQNT);
+    } catch (ArithmeticException e) {
+      throw new ParameterException(INCORRECT_ASSET_QUANTITY);
+    }
     if (newSupply > Constants.MAX_ASSET_QUANTITY_QNT) {
       throw new ParameterException(INCORRECT_ASSET_QUANTITY);
     }

--- a/src/brs/web/api/http/handler/SendMoneyMulti.java
+++ b/src/brs/web/api/http/handler/SendMoneyMulti.java
@@ -66,7 +66,7 @@ public final class SendMoneyMulti extends CreateTransaction {
         long recipientId = Convert.parseUnsignedLong(recipientArray[0]);
         Long amountNQT   = Convert.parseUnsignedLong(recipientArray[1]);
         recipients.add(new SimpleEntry<>("" + recipientId, amountNQT) );
-        totalAmountNQT += amountNQT;
+        totalAmountNQT = Convert.safeAdd(totalAmountNQT, amountNQT);
       }
     }
     catch(Exception e) {

--- a/src/brs/web/api/http/handler/SendMoneyMultiSame.java
+++ b/src/brs/web/api/http/handler/SendMoneyMultiSame.java
@@ -60,8 +60,9 @@ public final class SendMoneyMultiSame extends CreateTransaction {
 
     Collection<Long> recipients = new ArrayList<>();
 
-    long totalAmountNQT = amountNQT * recipientsArray.length;
+    long totalAmountNQT;
     try {
+      totalAmountNQT = Convert.safeMultiply(amountNQT, recipientsArray.length);
       for(String recipientId : recipientsArray) {
         recipients.add(Convert.parseUnsignedLong(recipientId));
       }


### PR DESCRIPTION
## Summary

Hardens monetary and asset arithmetic in consensus-adjacent paths after the SMART_FEES overflow advisory.

## What changed

- Replaced unchecked additions/subtractions/multiplications for block totals, remaining AT/subscription totals, block reward distribution, AT fees, asset supply checks, holder distribution totals, and multi-out API amount totals with `Convert.safe*` helpers.
- Rejects negative block monetary totals during block construction.
- Rejects negative transaction fees during transaction construction.
- Converts API overflow cases for multi-out and asset mint/distribution requests into normal invalid-parameter responses where applicable.

## Why

The SMART_FEES incident came from unchecked `long` arithmetic around externally influenced monetary totals. This PR applies the same overflow-safe pattern to nearby NQT/QNT aggregation paths so similar malformed values fail closed instead of wrapping.

## Validation

- `git diff --check` passes locally.
- Attempted `./gradlew.bat test --tests brs.services.impl.BlockServiceImplTest`, but the local environment only exposes Java 25 and Gradle/Groovy fails before compiling with `Unsupported class file major version 69`.

## Notes

This is intentionally scoped to arithmetic hardening and does not change fee policy or distribution formulas.